### PR TITLE
позиція кнопок

### DIFF
--- a/src/css/css-room/amenities.css
+++ b/src/css/css-room/amenities.css
@@ -158,9 +158,22 @@
     flex-direction: column;
     flex-wrap: wrap;
     align-content: flex-end;
-    margin-right: 199px;
+    margin-right: 100px;
   }
   .description-div {
     gap: 159px;
+  }
+
+  .amenities-btn {
+    font-size: 24px;
+    padding: 18px 38px;
+  }
+
+  .amenities-btn-hotpeg {
+    font-size: 20px;
+  }
+
+  .icon {
+    margin-left: 16px;
   }
 }


### PR DESCRIPTION
на екрані desktop
змінив margin-right  кнопок на 100 щоб візуально виглядали як на макеті
 по макету 199 вони візуально не стоять таяк мають.
на твій розсуд чи приймати зміни.